### PR TITLE
Fixes table crafting error

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -103,8 +103,7 @@
 				/obj/item/stack/cable_coil = 5,
 				/obj/item/weapon/gun/energy/gun/advtaser = 1,
 				/obj/item/weapon/stock_parts/cell = 1,
-				/obj/item/device/assembly/prox_sensor = 1,
-				/obj/item/robot_parts/r_arm = 1)
+				/obj/item/device/assembly/prox_sensor = 1)
 	tools = list(/obj/item/weapon/weldingtool, /obj/item/weapon/screwdriver)
 	time = 60
 	category = CAT_ROBOT


### PR DESCRIPTION
:cl: Fixes tablecrafting error
fix: fixed an error that required robot right arms for ed209 tablecrafting
/:cl:
