### PR TITLE
QoL changes for cluwne curse

### DIFF
--- a/code/modules/spells/spell_types/barnyard.dm
+++ b/code/modules/spells/spell_types/barnyard.dm
@@ -68,19 +68,25 @@
 
 	action_icon_state = "cluwne"
 
+/obj/effect/proc_holder/spell/targeted/cluwnecurse/proc/castfail()
+	charge_counter = 600
+	return
+
 /obj/effect/proc_holder/spell/targeted/cluwnecurse/cast(list/targets, mob/user = usr)
 	if(!targets.len)
 		user << "<span class='notice'>No target found in range.</span>"
 		return
 
-	var/mob/living/carbon/target = targets[1]
+	var/mob/living/carbon/human/target = targets[1]
 
 	if(!(target.type in compatible_mobs))
 		user << "<span class='notice'>You are unable to curse [target]!</span>"
+		castfail()
 		return
 
 	if(!(target in oview(range)))
 		user << "<span class='notice'>They are too far away!</span>"
+		castfail()
 		return
 
 // here begins the cluwning


### PR DESCRIPTION
Makes it so that casting Cluwne Curse on an incompatible mob refunds the spell, instead of putting you on cooldown. Also narrows down the list of potential targets so that basically only humans can be chosen. Should've been in from the start, no need for a changelog.
